### PR TITLE
fixes gpu build on windows

### DIFF
--- a/Core/regularisers_GPU/TV_FGP_GPU_core.h
+++ b/Core/regularisers_GPU/TV_FGP_GPU_core.h
@@ -1,10 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <memory.h>
-
 #ifndef _TV_FGP_GPU_
 #define _TV_FGP_GPU_
 
-extern "C" int TV_FGP_GPU_main(float *Input, float *Output, float lambdaPar, int iter, float epsil, int methodTV, int nonneg, int printM, int dimX, int dimY, int dimZ);
+#include "CCPiDefines.h"
+#include <memory.h>
+
+extern "C" CCPI_EXPORT int TV_FGP_GPU_main(float *Input, float *Output, float lambdaPar, int iter, float epsil, int methodTV, int nonneg, int printM, int dimX, int dimY, int dimZ);
 
 #endif 

--- a/Core/regularisers_GPU/TV_SB_GPU_core.h
+++ b/Core/regularisers_GPU/TV_SB_GPU_core.h
@@ -1,10 +1,10 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <memory.h>
-
 #ifndef _SB_TV_GPU_
 #define _SB_TV_GPU_
 
-extern "C" int TV_SB_GPU_main(float *Input, float *Output, float mu, int iter, float epsil, int methodTV, int printM, int dimX, int dimY, int dimZ);
+#include "CCPiDefines.h"
+#include <memory.h>
+
+
+extern "C" CCPI_EXPORT int TV_SB_GPU_main(float *Input, float *Output, float mu, int iter, float epsil, int methodTV, int printM, int dimX, int dimY, int dimZ);
 
 #endif 

--- a/Core/regularisers_GPU/dTV_FGP_GPU_core.h
+++ b/Core/regularisers_GPU/dTV_FGP_GPU_core.h
@@ -1,10 +1,9 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <memory.h>
-
 #ifndef _dTV_FGP_GPU_
 #define _dTV_FGP_GPU_
 
-extern "C" int dTV_FGP_GPU_main(float *Input, float *InputRef, float *Output, float lambdaPar, int iter, float epsil, float eta, int methodTV, int nonneg, int printM, int dimX, int dimY, int dimZ);
+#include "CCPiDefines.h"
+#include <memory.h>
+
+extern "C" CCPI_EXPORT int dTV_FGP_GPU_main(float *Input, float *InputRef, float *Output, float lambdaPar, int iter, float epsil, float eta, int methodTV, int nonneg, int printM, int dimX, int dimY, int dimZ);
 
 #endif 

--- a/Wrappers/Python/conda-recipe/meta.yaml
+++ b/Wrappers/Python/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ test:
   files:
     - lena_gray_512.tif
   requires:
-    - pillow
+    - pillow=4.1.1
 
 requirements:
   build:


### PR DESCRIPTION
* fixes the conda-build using the right version of pillow in yaml (4.1.1)
* fixes GPU headers for some modules according to CCPi defines