### PR TITLE
replace pow() when exponent is integer

### DIFF
--- a/src/Core/regularisers_CPU/Diffus4th_order_core.c
+++ b/src/Core/regularisers_CPU/Diffus4th_order_core.c
@@ -117,10 +117,10 @@ float Weighted_Laplc2D(float *W_Lapl, float *U0, float sigma, long dimX, long di
             index = j*dimX+i;
             
             gradX = 0.5f*(U0[j*dimX+i2] - U0[j*dimX+i1]);
-            gradX_sq = pow(gradX,2);
+            gradX_sq = gradX*gradX;
             
             gradY = 0.5f*(U0[j2*dimX+i] - U0[j1*dimX+i]);
-            gradY_sq = pow(gradY,2);
+            gradY_sq = gradY*gradY;
             
             gradXX = U0[j*dimX+i2] + U0[j*dimX+i1] - 2*U0[index];
             gradYY = U0[j2*dimX+i] + U0[j1*dimX+i] - 2*U0[index];
@@ -195,13 +195,13 @@ float Weighted_Laplc3D(float *W_Lapl, float *U0, float sigma, long dimX, long di
                 index = (dimX*dimY)*k + j*dimX+i;
                 
                 gradX = 0.5f*(U0[(dimX*dimY)*k + j*dimX+i2] - U0[(dimX*dimY)*k + j*dimX+i1]);
-                gradX_sq = pow(gradX,2);
+                gradX_sq = gradX*gradX;
                 
                 gradY = 0.5f*(U0[(dimX*dimY)*k + j2*dimX+i] - U0[(dimX*dimY)*k + j1*dimX+i]);
-                gradY_sq = pow(gradY,2);
+                gradY_sq = gradY*gradY;
                 
                 gradZ = 0.5f*(U0[(dimX*dimY)*k2 + j*dimX+i] - U0[(dimX*dimY)*k1 + j*dimX+i]);
-                gradZ_sq = pow(gradZ,2);
+                gradZ_sq = gradZ*gradZ;
                 
                 gradXX = U0[(dimX*dimY)*k + j*dimX+i2] + U0[(dimX*dimY)*k + j*dimX+i1] - 2*U0[index];
                 gradYY = U0[(dimX*dimY)*k + j2*dimX+i] + U0[(dimX*dimY)*k + j1*dimX+i] - 2*U0[index];

--- a/src/Core/regularisers_CPU/FGP_dTV_core.c
+++ b/src/Core/regularisers_CPU/FGP_dTV_core.c
@@ -189,6 +189,7 @@ float GradNorm_func2D(float *B, float *B_x, float *B_y, float eta, long dimX, lo
 {
     long i,j,index;
     float val1, val2, gradX, gradY, magn;
+    float eta_sq = eta*eta;
 #pragma omp parallel for shared(B, B_x, B_y) private(i,j,index,val1,val2,gradX,gradY,magn)
     for(j=0; j<dimY; j++) {
         for(i=0; i<dimX; i++) {
@@ -198,8 +199,8 @@ float GradNorm_func2D(float *B, float *B_x, float *B_y, float eta, long dimX, lo
             if (j == dimY-1) {val2 = 0.0f;} else {val2 = B[(j+1)*dimX + i];}
             gradX = val1 - B[index];
             gradY = val2 - B[index];
-            magn = pow(gradX,2) + pow(gradY,2);
-            magn = sqrt(magn + pow(eta,2)); /* the eta-smoothed gradients magnitude */
+            magn = gradX*gradX + gradY*gradY;
+            magn = sqrt(magn + eta_sq); /* the eta-smoothed gradients magnitude */
             B_x[index] = gradX/magn;
             B_y[index] = gradY/magn;
         }}
@@ -279,6 +280,7 @@ float GradNorm_func3D(float *B, float *B_x, float *B_y, float *B_z, float eta, l
 {
     long i, j, k, index;
     float val1, val2, val3, gradX, gradY, gradZ, magn;
+    float eta_sq = eta*eta;
 #pragma omp parallel for shared(B, B_x, B_y, B_z) private(i,j,k,index,val1,val2,val3,gradX,gradY,gradZ,magn)
     for(k=0; k<dimZ; k++) {
         for(j=0; j<dimY; j++) {
@@ -294,8 +296,8 @@ float GradNorm_func3D(float *B, float *B_x, float *B_y, float *B_z, float eta, l
                 gradX = val1 - B[index];
                 gradY = val2 - B[index];
                 gradZ = val3 - B[index];
-                magn = pow(gradX,2) + pow(gradY,2) + pow(gradZ,2);
-                magn = sqrt(magn + pow(eta,2)); /* the eta-smoothed gradients magnitude */
+                magn = gradX*gradX + gradY*gradY + gradZ*gradZ;
+                magn = sqrt(magn + eta_sq); /* the eta-smoothed gradients magnitude */
                 B_x[index] = gradX/magn;
                 B_y[index] = gradY/magn;
                 B_z[index] = gradZ/magn;

--- a/src/Core/regularisers_CPU/PatchSelect_core.c
+++ b/src/Core/regularisers_CPU/PatchSelect_core.c
@@ -72,7 +72,7 @@ float PatchSelect_CPU_main(float *A, unsigned short *H_i, unsigned short *H_j, u
         counterG = 0;
         for(i=-SimilarWin; i<=SimilarWin; i++) {
             for(j=-SimilarWin; j<=SimilarWin; j++) {
-                Eucl_Vec[counterG] = (float)exp(-(pow(((float) i), 2) + pow(((float) j), 2))/(2*SimilarWin*SimilarWin));
+                Eucl_Vec[counterG] = expf(-(i*i+j*j)/(2.0f*SimilarWin*SimilarWin));
                 counterG++;
             }} /*main neighb loop */
         /* for each pixel store indeces of the most similar neighbours (patches) */
@@ -90,7 +90,7 @@ float PatchSelect_CPU_main(float *A, unsigned short *H_i, unsigned short *H_j, u
         for(i=-SimilarWin; i<=SimilarWin; i++) {
             for(j=-SimilarWin; j<=SimilarWin; j++) {
                 for(k=-SimilarWin; k<=SimilarWin; k++) {
-                    Eucl_Vec[counterG] = (float)exp(-(pow(((float) i), 2) + pow(((float) j), 2) + pow(((float) k), 2))/(2*SimilarWin*SimilarWin*SimilarWin));
+                    Eucl_Vec[counterG] = expf(-(i*i+j*j+k*k)/(2.0f*SimilarWin*SimilarWin*SimilarWin));
                     counterG++;
                 }}} /*main neighb loop */
         
@@ -174,7 +174,7 @@ float Indeces2D(float *Aorig, unsigned short *H_i, unsigned short *H_j, float *W
 float Indeces3D(float *Aorig, unsigned short *H_i, unsigned short *H_j, unsigned short *H_k, float *Weights, long i, long j, long k, long dimY, long dimX, long dimZ, float *Eucl_Vec, int NumNeighb, int SearchWindow, int SimilarWin, float h2)
 {
     long i1, j1, k1, i_m, j_m, k_m, i_c, j_c, k_c, i2, j2, k2, i3, j3, k3, counter, x, y, index, sizeWin_tot, counterG;
-    float *Weight_Vec, normsum, temp;
+    float *Weight_Vec, normsum, temp, val;
     unsigned short *ind_i, *ind_j, *ind_k, temp_i, temp_j, temp_k;
     
     sizeWin_tot = (2*SearchWindow + 1)*(2*SearchWindow + 1)*(2*SearchWindow + 1);
@@ -204,7 +204,8 @@ float Indeces3D(float *Aorig, unsigned short *H_i, unsigned short *H_j, unsigned
                                 k3 = k + k_c;
                                 if (((i2 >= 0) && (i2 < dimX)) && ((j2 >= 0) && (j2 < dimY)) && ((k2 >= 0) && (k2 < dimZ))) {
                                     if (((i3 >= 0) && (i3 < dimX)) && ((j3 >= 0) && (j3 < dimY)) && ((k3 >= 0) && (k3 < dimZ))) {
-                                        normsum += Eucl_Vec[counterG]*pow(Aorig[(dimX*dimY*k3) + j3*dimX + (i3)] - Aorig[(dimX*dimY*k2) + j2*dimX + (i2)], 2);
+                                        val = Aorig[(dimX*dimY*k3) + j3*dimX + (i3)] - Aorig[(dimX*dimY*k2) + j2*dimX + (i2)];
+                                        normsum += Eucl_Vec[counterG]*val*val;
                                         counterG++;
                                     }}
                             }}}

--- a/src/Core/regularisers_CPU/TGV_core.c
+++ b/src/Core/regularisers_CPU/TGV_core.c
@@ -222,7 +222,7 @@ float ProjP_2D(float *P1, float *P2, long dimX, long dimY, float alpha1)
     for(j=0; j<dimY; j++) {
         for(i=0; i<dimX; i++) {
             index = j*dimX+i;
-            grad_magn = (sqrtf(pow(P1[index],2) + pow(P2[index],2)))/alpha1;
+            grad_magn = (sqrtf(P1[index]*P1[index] + P2[index]*P2[index]))/alpha1;
             if (grad_magn > 1.0f) {
                 P1[index] /= grad_magn;
                 P2[index] /= grad_magn;
@@ -263,7 +263,7 @@ float ProjQ_2D(float *Q1, float *Q2, float *Q3, long dimX, long dimY, float alph
     for(j=0; j<dimY; j++) {
         for(i=0; i<dimX; i++) {
             index = j*dimX+i;
-            grad_magn = sqrtf(pow(Q1[index],2) + pow(Q2[index],2) + 2*pow(Q3[index],2));
+            grad_magn = sqrtf(Q1[index]*Q1[index] + Q2[index]*Q2[index] + 2*Q3[index]*Q3[index]);
             grad_magn = grad_magn/alpha0;
             if (grad_magn > 1.0f) {
                 Q1[index] /= grad_magn;
@@ -376,7 +376,7 @@ float ProjP_3D(float *P1, float *P2, float *P3, long dimX, long dimY, long dimZ,
         for(j=0; j<dimY; j++) {
             for(i=0; i<dimX; i++) {
                 index = (dimX*dimY)*k + j*dimX+i;
-                grad_magn = (sqrtf(pow(P1[index],2) + pow(P2[index],2) + pow(P3[index],2)))/alpha1;
+                grad_magn = (sqrtf(P1[index]*P1[index] + P2[index]*P2[index]+ P3[index]*P3[index]))/alpha1;
                 if (grad_magn > 1.0f) {
                     P1[index] /= grad_magn;
                     P2[index] /= grad_magn;
@@ -431,7 +431,7 @@ float ProjQ_3D(float *Q1, float *Q2, float *Q3, float *Q4, float *Q5, float *Q6,
         for(j=0; j<dimY; j++) {
             for(i=0; i<dimX; i++) {
                 index = (dimX*dimY)*k + j*dimX+i;
-                grad_magn = sqrtf(pow(Q1[index],2) + pow(Q2[index],2) + pow(Q3[index],2) + 2.0f*pow(Q4[index],2) + 2.0f*pow(Q5[index],2) + 2.0f*pow(Q6[index],2));
+                grad_magn = sqrtf(Q1[index]*Q1[index] + Q2[index]*Q2[index] + Q3[index]*Q3[index] + 2.0f*Q4[index]*Q4[index] + 2.0f*Q5[index]*Q5[index] + 2.0f*Q6[index]*Q6[index]);
                 grad_magn = grad_magn/alpha0;
                 if (grad_magn > 1.0f) {
                     Q1[index] /= grad_magn;


### PR DESCRIPTION
`pow()` is slow when the exponent is integer so I've replaced these instances (i.e. `pow(x,2,)` -> `x*x`). Especially inside loops this gives a significant speedup.