### PR TITLE
CI: add GHA workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: build
       run: |
-        cmake -S . -B ./build_proj -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_MATLAB_WRAPPER=ON -DBUILD_PYTHON_WRAPPER=ON -DBUILD_CUDA=OFF -DCMAKE_INSTALL_PREFIX=./install
+        cmake -S . -B ./build_proj -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_MATLAB_WRAPPER=OFF -DBUILD_PYTHON_WRAPPER=ON -DBUILD_CUDA=OFF -DCMAKE_INSTALL_PREFIX=./install
         cmake --build ./build_proj --target install
         pip install ./src/Python
     - name: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: build
+on:
+  release:
+    types: [published]
+  push:
+    branches: [master]
+    tags: ['**']
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    defaults: {run: {shell: 'bash -el {0}'}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - python-version: 3.8
+          numpy-version: 1.21
+        - python-version: '3.10'
+          numpy-version: 1.24
+    steps:
+    - uses: actions/checkout@v4
+      with: {fetch-depth: 0, submodules: recursive}
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: build
+      run: |
+        cmake -S . -B ./build_proj -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_MATLAB_WRAPPER=ON -DBUILD_PYTHON_WRAPPER=ON -DBUILD_CUDA=OFF -DCMAKE_INSTALL_PREFIX=./install
+        cmake --build ./build_proj --target install
+        pip install ./src/Python
+    - name: test
+      run: PYTHONPATH=./src/Python python -m unittest discover ./test
+  conda:
+    defaults: {run: {shell: 'bash -el {0}'}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+        numpy-version: [1.22]
+    steps:
+    - uses: actions/checkout@v4
+      with: {fetch-depth: 0, submodules: recursive}
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+    - name: conda build & test
+      working-directory: recipe
+      run: |
+        conda install boa
+        conda mambabuild . -c conda-forge -c ccpi --python=${{ matrix.python-version }} --numpy=${{ matrix.numpy-version }} --output-folder .
+    - name: Upload artifact of the conda package
+      uses: actions/upload-artifact@v4
+      with:
+        name: ccpi-regulariser-package
+        path: recipe/linux-64/ccpi-regulariser*
+  pass:
+    needs: [test, conda]
+    runs-on: ubuntu-latest
+    steps: [{run: echo success}]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - pip
     - vc 14 # [win]
     - cmake
-    - ripgrep
 
   run:
     - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}

--- a/src/Python/pyproject.toml
+++ b/src/Python/pyproject.toml
@@ -9,3 +9,4 @@ include = ["ccpi", "ccpi.*"]
 [project]
 version = "24.0.0"
 name = "ccpi-regulariser"
+dependencies = ["numpy"]


### PR DESCRIPTION
- [x] add (CPU) workflow
- [x] fix dependencies

N.B. adding conda token for releases would depend on GPU workflows, which in turn depends on #181